### PR TITLE
Deferred improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "apt-cmd"
@@ -428,9 +428,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cairo-rs"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129e928d3eda625f53ce257589efbe5143416875fd01bddd08c8c6feb8b9962b"
+checksum = "62be3562254e90c1c6050a72aa638f6315593e98c5cdaba9017cedbabf0a5dee"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-sys-rs",
@@ -1154,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678516f1baef591d270ca10587c01a12542a731a7879cc62391a18191a470831"
+checksum = "ad38dd9cc8b099cceecdf41375bb6d481b1b5a7cd5cd603e10a69a9383f8619a"
 dependencies = [
  "bitflags 1.3.2",
  "gdk-pixbuf-sys",
@@ -1226,9 +1226,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "gio"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cd21a7a674ea811749661012512b0ba5237ba404ccbcab2850db5537549b64"
+checksum = "0f132be35e05d9662b9fa0fee3f349c6621f7782e0105917f4cc73c1bf47eceb"
 dependencies = [
  "bitflags 1.3.2",
  "futures-channel",
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a826fad715b57834920839d7a594c3b5e416358c7d790bdaba847a40d7c1d96d"
+checksum = "bd124026a2fa8c33a3d17a3fe59c103f2d9fa5bd92c19e029e037736729abeab"
 dependencies = [
  "bitflags 1.3.2",
  "futures-channel",
@@ -1276,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac4d47c544af67747652ab1865ace0ffa1155709723ac4f32e97587dd4735b2"
+checksum = "25a68131a662b04931e71891fb14aaf65ee4b44d08e8abc10f49e77418c86c64"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -1312,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "gtk"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d1326b36af927fe46ae2f89a8fec38c6f0d279ebc5ef07ffeeabb70300bfc"
+checksum = "92e3004a2d5d6d8b5057d2b57b3712c9529b62e82c77f25c1fecde1fd5c23bd0"
 dependencies = [
  "atk",
  "bitflags 1.3.2",
@@ -2225,9 +2225,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -3100,9 +3100,9 @@ checksum = "29738eedb4388d9ea620eeab9384884fc3f06f586a2eddb56bedc5885126c7c1"
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3242,9 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",

--- a/daemon/src/accounts.rs
+++ b/daemon/src/accounts.rs
@@ -14,7 +14,7 @@ pub fn is_desktop_account(euid: u32) -> bool {
 /// Users which are defined as being desktop accounts.
 ///
 /// On Linux, this means the user ID is between `UID_MIN` and `UID_MAX` in `/etc/login.defs`.
-pub fn user_names() -> Box<dyn Iterator<Item = String>> {
+pub fn user_names() -> Box<dyn Iterator<Item = String> + Send> {
     let (uid_min, uid_max) = match uid_min_max() {
         Ok(v) => v,
         Err(_) => return Box::new(std::iter::empty()),

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -12,7 +12,7 @@ mod signal_handler;
 mod utils;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     std::env::set_var("LANG", "C");
     if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "info");
@@ -32,9 +32,11 @@ async fn main() {
     let main_future = async move {
         let effective_uid = users::get_effective_uid();
         if effective_uid == 0 {
-            crate::service::system::run().await;
+            crate::service::system::run().await
         } else if accounts::is_desktop_account(effective_uid) {
-            let _ = crate::service::session::run().await;
+            crate::service::session::run().await
+        } else {
+            Err(anyhow::anyhow!("service must be launched from either root or a desktop user"))
         }
     };
 

--- a/daemon/src/notify.rs
+++ b/daemon/src/notify.rs
@@ -35,7 +35,7 @@ pub fn notify<F: FnOnce()>(summary: &str, body: &str, func: F) {
         });
 }
 
-pub async fn updates_available() {
+pub fn updates_available() {
     notify(
         "System updates are available to install",
         "Click here to view available updates",

--- a/daemon/src/notify.rs
+++ b/daemon/src/notify.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use notify_rust::{Hint, Notification, Urgency};
 
-pub async fn notify<F: FnOnce()>(summary: &str, body: &str, func: F) {
+pub fn notify<F: FnOnce()>(summary: &str, body: &str, func: F) {
     let show_notification = || {
         Notification::new()
             .icon("distributor-logo")
@@ -21,7 +21,7 @@ pub async fn notify<F: FnOnce()>(summary: &str, body: &str, func: F) {
     let mut notification = show_notification();
 
     while notification.is_err() {
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        std::thread::sleep(Duration::from_secs(1));
 
         notification = show_notification();
     }
@@ -49,8 +49,7 @@ pub async fn updates_available() {
                     .await;
             });
         },
-    )
-    .await
+    );
 }
 
 /// Restart the appcenter to force that the packagekit cache is refreshed.

--- a/daemon/src/notify.rs
+++ b/daemon/src/notify.rs
@@ -36,8 +36,6 @@ pub fn notify<F: FnOnce()>(summary: &str, body: &str, func: F) {
 }
 
 pub async fn updates_available() {
-    restart_appcenter().await;
-
     notify(
         "System updates are available to install",
         "Click here to view available updates",
@@ -50,19 +48,4 @@ pub async fn updates_available() {
             });
         },
     );
-}
-
-/// Restart the appcenter to force that the packagekit cache is refreshed.
-async fn restart_appcenter() {
-    let _ = tokio::process::Command::new("killall")
-        .arg(APPCENTER)
-        .status()
-        .await;
-
-    tokio::spawn(async move {
-        tokio::process::Command::new(APPCENTER)
-            .arg("-s")
-            .status()
-            .await
-    });
 }

--- a/daemon/src/package_managers/apt.rs
+++ b/daemon/src/package_managers/apt.rs
@@ -141,6 +141,7 @@ pub async fn upgrade() -> anyhow::Result<()> {
         result = AptGet::new()
             .noninteractive()
             .autoremove()
+            .force()
             .status()
             .await
             .context("failed to autoremove packages");

--- a/daemon/src/package_managers/apt.rs
+++ b/daemon/src/package_managers/apt.rs
@@ -127,7 +127,7 @@ pub async fn upgrade() -> anyhow::Result<()> {
 
     let _ = AptMark::new().hold(["pop-system-updater"]).await;
 
-    let result = AptGet::new()
+    let mut result = AptGet::new()
         .noninteractive()
         .force()
         .allow_downgrades()
@@ -136,6 +136,15 @@ pub async fn upgrade() -> anyhow::Result<()> {
         .context("failed to install updates");
 
     let _ = AptMark::new().unhold(["pop-system-updater"]).await;
+
+    if result.is_ok() {
+        result = AptGet::new()
+            .noninteractive()
+            .autoremove()
+            .status()
+            .await
+            .context("failed to autoremove packages");
+    }
 
     result
 }

--- a/daemon/src/package_managers/nix.rs
+++ b/daemon/src/package_managers/nix.rs
@@ -10,10 +10,13 @@ pub async fn update(conn: &zbus::Connection) {
         return;
     }
 
-    let upgrade = &["nix-env", "--upgrade"];
-    let prune = &["nix-collect-garbage", "-d"];
+    const COMMANDS: &[&[&str]] = &[
+        &["nix-channel", "--update"],
+        &["nix-env", "--upgrade"],
+        &["nix-collect-garbage", "-d"],
+    ];
 
-    if let Err(why) = utils::async_commands(&[upgrade, prune]).await {
+    if let Err(why) = utils::async_commands(COMMANDS).await {
         utils::error_handler(conn, SOURCE, why).await;
     }
 }

--- a/daemon/src/package_managers/nix.rs
+++ b/daemon/src/package_managers/nix.rs
@@ -6,15 +6,17 @@ use crate::utils;
 pub async fn update(conn: &zbus::Connection) {
     const SOURCE: &str = "nix";
 
-    if !utils::command_exists("nix-env") {
-        return;
-    }
-
     const COMMANDS: &[&[&str]] = &[
         &["nix-channel", "--update"],
         &["nix-env", "--upgrade"],
         &["nix-collect-garbage", "-d"],
     ];
+
+    for command in COMMANDS {
+        if !utils::command_exists(command[0]) {
+            return;
+        }
+    }
 
     if let Err(why) = utils::async_commands(COMMANDS).await {
         utils::error_handler(conn, SOURCE, why).await;

--- a/daemon/src/service/session.rs
+++ b/daemon/src/service/session.rs
@@ -114,7 +114,9 @@ impl State {
         let f2 = async {
             if crate::package_managers::updates_are_available().await {
                 info!("displaying notification of available updates");
+                let handle = tokio::runtime::Handle::current();
                 std::thread::spawn(move || {
+                    let _reactor_context = handle.enter();
                     crate::notify::updates_available();
                 });
             }

--- a/daemon/src/service/session.rs
+++ b/daemon/src/service/session.rs
@@ -114,7 +114,9 @@ impl State {
         let f2 = async {
             if crate::package_managers::updates_are_available().await {
                 info!("displaying notification of available updates");
-                crate::notify::updates_available().await;
+                std::thread::spawn(move || {
+                    crate::notify::updates_available();
+                });
             }
         };
 

--- a/daemon/src/service/session.rs
+++ b/daemon/src/service/session.rs
@@ -43,13 +43,13 @@ pub async fn run() -> anyhow::Result<()> {
         .await
         .context("failed to serve service")?;
 
-        connection
-            .request_name("com.system76.SystemUpdater.Local")
-            .await
-            .map_err(|why| match why {
-                zbus::Error::NameTaken => anyhow::anyhow!("user service is already active"),
-                other => anyhow::anyhow!("could not register user service: {}", other)
-            })?;
+    connection
+        .request_name("com.system76.SystemUpdater.Local")
+        .await
+        .map_err(|why| match why {
+            zbus::Error::NameTaken => anyhow::anyhow!("user service is already active"),
+            other => anyhow::anyhow!("could not register user service: {}", other),
+        })?;
 
     let mut state = State {
         cache: config::load_session_cache().await,

--- a/daemon/src/service/system.rs
+++ b/daemon/src/service/system.rs
@@ -40,7 +40,7 @@ impl Service {
         let connection = connection.clone();
         let updating = self.updating.clone();
 
-        self.update_task = Some(tokio::task::spawn_local(async move {
+        self.update_task = Some(tokio::task::spawn(async move {
             let _ = futures::join!(
                 crate::package_managers::apt::update(connection.clone()),
                 crate::package_managers::flatpak::update(connection.clone()),
@@ -163,7 +163,7 @@ pub async fn run() -> anyhow::Result<()> {
         .await
         .map_err(|why| match why {
             zbus::Error::NameTaken => anyhow::anyhow!("system service is already active"),
-            other => anyhow::anyhow!("could not register system service: {}", other)
+            other => anyhow::anyhow!("could not register system service: {}", other),
         })?;
 
     info!("DBus connection established");

--- a/gtk/src/bsb.rs
+++ b/gtk/src/bsb.rs
@@ -22,14 +22,20 @@ impl std::ops::Deref for BetterSpinButton {
 impl BetterSpinButton {
     pub fn new(min: u32, max: u32, inc_small: u32, inc_large: u32, padding: u32) -> Self {
         // Increase the value while preventing it from exceeding the max.
-        let increase = move |value: u32, inc: u32| (value + inc).min(max);
+        let increase = move |value: u32, inc: u32| {
+            if value + inc > max {
+                min
+            } else {
+                value + inc
+            }
+        };
 
         // Decrease the value while preventing it from exceeding the min.
         let decrease = move |value: u32, inc: u32| {
-            if value < inc {
-                min
+            if min + inc > value {
+                max
             } else {
-                (value - inc).max(min)
+                value - inc
             }
         };
 
@@ -115,9 +121,9 @@ impl BetterSpinButton {
                 let new_value = match text.as_str().parse::<u32>() {
                     Ok(value) => {
                         if value < min {
-                            min
-                        } else if value > max {
                             max
+                        } else if value > max {
+                            min
                         } else {
                             value
                         }

--- a/gtk/src/dialog.rs
+++ b/gtk/src/dialog.rs
@@ -74,12 +74,12 @@ impl Dialog {
                     .build();
 
                 hour = cascade! {
-                    crate::bsb::BetterSpinButton::new(1, 12, 1, 3, 2);
+                    crate::bsb::BetterSpinButton::new(1, 12, 1, 1, 2);
                     ..set_valign(gtk::Align::Center);
                 };
 
                 minute = cascade! {
-                    crate::bsb::BetterSpinButton::new(0, 59, 1, 10, 2);
+                    crate::bsb::BetterSpinButton::new(0, 59, 1, 1, 2);
                     ..set_valign(gtk::Align::Center);
                 };
 


### PR DESCRIPTION
Resolves some of the items from https://github.com/pop-os/upgrade/issues/279

- Make up/down keys increment spinboxes by 1 instead of 3
- Make hours/minutes roll over when incrementing or decrementing beyond their limits.
- Consider making system-updater run apt autoremove to keep clutter from building up on the system
- Make the Pop!_Shop not immediately recheck for updates after clicking a notification from system-updater

Some other fixes include

- Run nix-channel --update before upgrading nix-env packages
- Avoid blocking the user service when a notification is shown
- Improved error messages on service startup
- Perf optimization from spawning main future on tokio runtime

Note that the GTK crate changes can only be tested from running the GTK demo locally with `just run`. An update to the system-updater dependency in pop-upgrade will get the change applied there.