### PR TITLE
fix: Set start limit burst to 3

### DIFF
--- a/data/com.system76.SystemUpdater.Local.service
+++ b/data/com.system76.SystemUpdater.Local.service
@@ -10,7 +10,7 @@ BusName=com.system76.SystemUpdater.Local
 Restart=on-failure
 ExecStartPre=/bin/sleep 10
 ExecStart=/usr/bin/pop-system-updater
-StartLimitBurst=1
+StartLimitBurst=3
 
 [Install]
 Alias=pop-system-updater-local.service


### PR DESCRIPTION
This will fix systems unable to configure and enable automatic updates due to this error

```
INFO pop_system_updater::service::session: Restarting service in 5s because DISPLAY could not be found
```

Since we have a limit burst of 1 and a limit interval of 1d, this would prevent the service from being started again for 1 day.